### PR TITLE
fixt import addon versions for Gotham alpha10

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,11 +4,11 @@
        version="3.0.4"
        provider-name="Giftie">
   <requires>
-    <import addon="xbmc.addon" version="12.0.0"/>
+    <import addon="xbmc.addon" version="12.0"/>
     <import addon="xbmc.json" version="6.0.0"/>
     <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.pil" version="1.1.7"/>
-    <import addon="script.module.simplejson" version="2.0.10"/>
+    <import addon="script.module.simplejson" version="3.3.0"/>
   </requires>
   <extension point="xbmc.python.script"
              library="default.py">


### PR DESCRIPTION
fixes the xbmc.addon version to 12.0 and script.module.simplejson version to 3.3.0
not cdartmanager can be installed in gotham alpha10
NOTE: you have to correct your script.module.pil.
i've corrected it on xbmc git.
